### PR TITLE
Update Web.ShadowUI.csproj

### DIFF
--- a/Source/Web.ShadowUI/Web.ShadowUI/Web.ShadowUI.csproj
+++ b/Source/Web.ShadowUI/Web.ShadowUI/Web.ShadowUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <CopyRefAssembliesToPublishDirectory>false</CopyRefAssembliesToPublishDirectory>
   </PropertyGroup>
 


### PR DESCRIPTION
The net5.0 support has been discontinued, the project can now be used with net7.0 and VisualStudio 2022. ASP.NET and IISExpress are required.